### PR TITLE
Fix NEWS formatting for pkgdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-2020-10-01	Version 0.0-1
+# Version 0.0-1 (2020-10-01	)
 
 * Package release 
 


### PR DESCRIPTION
We see

```
 x callr subprocess failed: Invalid NEWS.md: inconsistent use of section headings.
ℹ Top-level headings must be either all <h1> or all <h2>.
ℹ See ?build_news for more details. 
```

in https://github.com/r-universe/ropensci/runs/4841826080?check_suite_focus=true via https://ropensci.r-universe.dev/ui#builds